### PR TITLE
README.md update

### DIFF
--- a/htdocs/silo/migrations/0004_auto_20151014_1122.py
+++ b/htdocs/silo/migrations/0004_auto_20151014_1122.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('silo', '0003_documentationapp_faq_feedback'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='read',
+            name='owner',
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/htdocs/silo/migrations/0006_merge.py
+++ b/htdocs/silo/migrations/0006_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('silo', '0004_auto_20151014_1122'),
+        ('silo', '0005_auto_20151014_1539'),
+    ]
+
+    operations = [
+    ]

--- a/htdocs/silo/migrations/0007_merge.py
+++ b/htdocs/silo/migrations/0007_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('silo', '0006_auto_20151222_1252'),
+        ('silo', '0006_merge'),
+    ]
+
+    operations = [
+    ]


### PR DESCRIPTION
Tola Tables
====
Share, Load, Edit and Display data from various mobile data collection platforms.

The Read app is intended for use with FormHub or Ona data collection platform.  You should be able
to add an additional app using Read as a template to import data or create new "reads"
from other data sources.  You only need to import the new app, add the new read templates
and update the base template to include your new app as sub-navigation to the main read.

Feed: A new JSON or XML feed of one or more aggregated data sources<br>
Read: A data source to load data into the system from<br>
Silo: A data store that can combine one or more Feeds (Data sources)<br>
Display: Where data is viewed and edited<br>

## Install virtualenv

$ pip install virtualenv

## Create Virtualenv
$ virtualenv ENV
* Where ENV is a directory to place the new virtual environment. You can name it as wanted. It contains the Python executable files, and a copy of the pip library

## Activate Virtualenv
$ source bin/activate

## Fix probable mysql path issue (for mac)
$ export PATH=$PATH:/usr/local/mysql/bin
* or whatever path you have to your installed mysql_config file in the bin folder of mysql

$ pip install -r requirements.txt

## Set up DB
$ python manage.py syncdb

## Run App
If your using more then one settings file change manage.py to point to local or dev file first

$ python manage.py runserver 0.0.0.0:8000

GOOGLE API 
$ sudo pip install --upgrade google-api-python-client
* 0’s let it run on any local address i.e. localhost,127.0.0.1 etc.
